### PR TITLE
Update GitHub Action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ outputs:
     status:
         description: 'The result of the checks'
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'src/action/action-entry-point.js'


### PR DESCRIPTION
## Summary
- Updates `action.yml` runtime from `node20` to `node24`
- Eliminates engine warnings for dependencies that require `node >= 22`
- GitHub Actions supports `node12`, `node16`, `node20`, and `node24` (no `node22` option)

## Test plan
- [ ] Verify the action runs successfully on a PR in a consuming repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)