### PR TITLE
Add requireFreshReviews config option

### DIFF
--- a/src/action/run-action.ts
+++ b/src/action/run-action.ts
@@ -68,7 +68,12 @@ async function runAction() {
             throw new Error('Aborting checks because Pull Request is a draft.');
         }
 
-        const reviews = await getCompleteReviewStatus({octokit, pullRequest, repo});
+        const reviews = await getCompleteReviewStatus({
+            octokit,
+            pullRequest,
+            repo,
+            requireFreshReviews: !!config.requireFreshReviews,
+        });
         log.faint('current approvals');
         logJson(reviews, 'faint');
         const git = simpleGit(repoDir);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -183,6 +183,15 @@ export const pullRequestVirConfigShape = defineShape({
      */
     reviewRules: optionalShape([reviewRuleShape]),
     /**
+     * Treat approvals as invalid if they were submitted before the latest commit on the pull
+     * request. This helps ensure reviewers have seen the latest code changes.
+     *
+     * Note: this will also invalidate reviews after a rebase, even if the code hasn't changed.
+     *
+     * @default false
+     */
+    requireFreshReviews: optionalShape(false),
+    /**
      * Inserts the usernames of code owners into a pull request's description.
      *
      * @default true

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -35,7 +35,7 @@ export async function getCompleteReviewStatus({
     );
 }
 
-export function parseReviews(
+function parseReviews(
     requestedReviewers: ReadonlyArray<Readonly<GithubUser>>,
     submittedReviews: ReadonlyArray<Readonly<GithubReview>>,
     latestCommitDate?: string,

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -1,4 +1,4 @@
-import {type SelectFrom} from '@augment-vir/common';
+import {log, type SelectFrom} from '@augment-vir/common';
 import {type PullRequestReviews, type ScriptParams} from '../config/config.js';
 import {
     GithubGraphqlReviewState,
@@ -13,24 +13,45 @@ export async function getCompleteReviewStatus({
     pullRequest,
     octokit,
     repo,
+    requireFreshReviews,
 }: {
     pullRequest: Readonly<GithubPullRequest>;
     octokit: Readonly<Octokit>;
     repo: Readonly<GithubRepo>;
+    requireFreshReviews: boolean;
 }) {
-    const submittedReviews = await fetchSubmittedReviews({octokit, pullRequest, repo});
+    const {reviews: submittedReviews, latestCommitDate} = await fetchSubmittedReviews({
+        octokit,
+        pullRequest,
+        repo,
+    });
 
     const requestedReviewers = pullRequest.requested_reviewers || [];
 
-    return parseReviews(requestedReviewers, submittedReviews);
+    return parseReviews(
+        requestedReviewers,
+        submittedReviews,
+        requireFreshReviews ? latestCommitDate : undefined,
+    );
 }
 
-function parseReviews(
+export function parseReviews(
     requestedReviewers: ReadonlyArray<Readonly<GithubUser>>,
     submittedReviews: ReadonlyArray<Readonly<GithubReview>>,
+    latestCommitDate?: string,
 ): PullRequestReviews {
     const approvals = submittedReviews.reduce((accum, review) => {
-        accum[review.author.login] = review.state === GithubGraphqlReviewState.Approved;
+        const isApproved = review.state === GithubGraphqlReviewState.Approved;
+
+        if (isApproved && latestCommitDate && review.submittedAt < latestCommitDate) {
+            log.faint(
+                `Stale approval from '${review.author.login}': reviewed at ${review.submittedAt}, latest commit at ${latestCommitDate}`,
+            );
+            accum[review.author.login] = false;
+        } else {
+            accum[review.author.login] = isApproved;
+        }
+
         return accum;
     }, {} as PullRequestReviews);
 
@@ -59,7 +80,7 @@ async function fetchSubmittedReviews({
             number: true;
         };
     }
->): Promise<GithubReview[]> {
+>): Promise<{reviews: GithubReview[]; latestCommitDate: string}> {
     const results: any = await octokit.graphql(
         /* GraphQL */ `
             query ($owner: String!, $repo: String!, $pullNumber: Int!) {
@@ -76,6 +97,13 @@ async function fetchSubmittedReviews({
                                 state
                             }
                         }
+                        commits(last: 1) {
+                            nodes {
+                                commit {
+                                    committedDate
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -87,5 +115,8 @@ async function fetchSubmittedReviews({
         },
     );
 
-    return results.repository.pullRequest.latestOpinionatedReviews.nodes;
+    return {
+        reviews: results.repository.pullRequest.latestOpinionatedReviews.nodes,
+        latestCommitDate: results.repository.pullRequest.commits.nodes[0]?.commit.committedDate,
+    };
 }


### PR DESCRIPTION
## Summary
- Adds a new `requireFreshReviews` config option (default `false`) that treats approvals as invalid if they were submitted before the latest commit on the PR
- Extends the existing GraphQL query to also fetch the latest commit's `committedDate`
- Compares each review's `submittedAt` against that timestamp in `parseReviews`
- Includes 7 new test cases covering stale/fresh approvals, edge cases, and backward compatibility

**Known limitation:** Rebases change commit timestamps even when no code changes, so this will invalidate reviews after a simple rebase. This trade-off was discussed and accepted.

## Test plan
- [x] All 20 existing + new tests pass locally
- [ ] Enable `requireFreshReviews: true` in a consuming repo's config and verify stale approvals are rejected
- [ ] Verify default behavior (`requireFreshReviews` absent/false) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)